### PR TITLE
施設を超えてぶちかまさないように修正

### DIFF
--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -13885,7 +13885,7 @@ class AetherRaidTacticsBoard {
             }
 
             // 壁などが途中にあったらぶちかましなどを行えない
-            if (!tile.isMovableTile()) {
+            if (!tile.isMovableTile() || tile.obj instanceof StructureBase) {
                 moveTile = null;
                 continue;
             }


### PR DESCRIPTION
ぶちかませるかの判定にtile.isMovableTile()しか参照していなかったのでtile.objがStructureBaseであるかどうかの判定を追加しました。