### PR TITLE
ダメージマイナスでダメージ量がマイナスになりHPが回復しないように修正

### DIFF
--- a/Sources/DamageCalculator.js
+++ b/Sources/DamageCalculator.js
@@ -1608,7 +1608,7 @@ class DamageCalculator {
 
     __calcUnitAttackDamage(defUnit, damage, damageReductionRatio, damageReductionValue, activatesDefenderSpecial) {
         let reducedDamage = Math.trunc(damage * damageReductionRatio) + damageReductionValue;
-        var currentDamage = damage - reducedDamage;
+        var currentDamage = Math.max(damage - reducedDamage, 0);
         if (damageReductionRatio > 0.0) {
             this.writeDebugLog("ダメージ軽減" + Math.trunc(damageReductionRatio * 100) + "%");
             this.writeDebugLog("ダメージ-" + damageReductionValue);


### PR DESCRIPTION
盾の鼓動でダメージがない場合にHPが逆に5回復してしまっていたので修正しました。
ダメージをマイナスから0に修正するタイミングが複数考えられますがこの場所で良いか確認をお願いします。