### PR TITLE
高貴な燭台の実装を追加

### DIFF
--- a/Sources/DamageCalculator.js
+++ b/Sources/DamageCalculator.js
@@ -180,6 +180,11 @@ class DamageCalculator {
 
     __setBothOfAtkDefSkillEffetToContext(unit, enemyUnit) {
         switch (unit.weapon) {
+            case Weapon.CourtlyCandle:
+                if (unit.snapshot.restHpPercentage >= 50 && enemyUnit.battleContext.canFollowupAttack) {
+                    unit.battleContext.damageReductionRatioOfFirstAttack = 0.5;
+                }
+                break;
             case Weapon.SummerStrikers:
                 if (unit.battleContext.initiatesCombat && unit.snapshot.restHpPercentage >= 25) {
                     unit.battleContext.damageReductionRatioOfFirstAttack = 0.75;

--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -5792,6 +5792,12 @@ class AetherRaidTacticsBoard {
 
         for (let skillId of targetUnit.enumerateSkills()) {
             switch (skillId) {
+                case Weapon.CourtlyCandle:
+                    if (targetUnit.snapshot.restHpPercentage >= 50) {
+                        targetUnit.atkSpur += 5;
+                        targetUnit.defSpur += 5;
+                    }
+                    break;
                 case PassiveB.CraftFighter3:
                     if (!targetUnit.battleContext.initiatesCombat
                         && targetUnit.snapshot.restHpPercentage >= 25

--- a/Sources/Skill.js
+++ b/Sources/Skill.js
@@ -772,6 +772,8 @@ const Weapon = {
     DanielMadeBow: 1447, // ダニエルの錬弓
 
     PrimordialBreath: 1468, // 神祖竜のブレス
+
+    CourtlyCandle: 1478, // 高貴な燭台
 };
 
 var Support = {


### PR DESCRIPTION
効果は「戦闘開始時、自分のHPが50％以上なら、戦闘中、攻撃、守備+5、かつ、敵が追撃可能なら、最初に受けた攻撃のダメージを50％軽減」です。