### PR TITLE
見切り・追撃効果がかからないスキルがあるバグを修正

### DIFF
--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -5065,7 +5065,9 @@ class AetherRaidTacticsBoard {
                     if (targetUnit.battleContext.initiatesCombat || targetUnit.battleContext.isThereAnyUnitIn2Spaces) {
                         targetUnit.addAllSpur(5);
                         if (enemyUnit.snapshot.restHpPercentage === 100) {
-                            targetUnit.battleContext.followupAttackPriority++;
+                            if (!this.__canInvalidateAbsoluteFollowupAttack(enemyUnit, targetUnit)) {
+                                targetUnit.battleContext.followupAttackPriority++;
+                            }
                         }
                     }
                     break;
@@ -5206,7 +5208,9 @@ class AetherRaidTacticsBoard {
                         && targetUnit.snapshot.restHpPercentage >= 25
                     ) {
                         targetUnit.battleContext.reducesCooldownCount = true;
-                        ++targetUnit.battleContext.followupAttackPriority;
+                        if (!this.__canInvalidateAbsoluteFollowupAttack(enemyUnit, targetUnit)) {
+                            ++targetUnit.battleContext.followupAttackPriority;
+                        }
                     }
                     break;
                 case Weapon.Garumu:
@@ -5569,7 +5573,9 @@ class AetherRaidTacticsBoard {
                             if (enemyUnit.snapshot.restHpPercentage >= 50) {
                                 targetUnit.atkSpur += 5;
                                 targetUnit.defSpur += 5;
-                                targetUnit.battleContext.followupAttackPriority++;
+                                if (!this.__canInvalidateAbsoluteFollowupAttack(enemyUnit, targetUnit)) {
+                                    targetUnit.battleContext.followupAttackPriority++;
+                                }
                             }
                         }
                     }
@@ -5635,7 +5641,9 @@ class AetherRaidTacticsBoard {
                             if (targetUnit.snapshot.restHpPercentage >= 50) {
                                 targetUnit.atkSpur += 5;
                                 targetUnit.resSpur += 5;
-                                targetUnit.battleContext.followupAttackPriority++;
+                                if (!this.__canInvalidateAbsoluteFollowupAttack(enemyUnit, targetUnit)) {
+                                    targetUnit.battleContext.followupAttackPriority++;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
現在__examinesCanFollowupAttackFor<XXX>の中で追撃無効がなければfollow up priorityを変化させる実装になっていますが、一部のスキル(シグルド・ミカヤの錬成など)で__examinesCanFollowupAttackFor<XXX>の外(applySkillEffectForUnitなど)でfollow up priorityを変化させてしまっていたので見切り追撃を持っていても絶対追撃が出てしまうバグがありました。

今回は単純にif (!this.__canInvalidateAbsoluteFollowupAttack(enemyUnit, targetUnit))で囲って修正しましたが、
追撃判定時に見切りがあるかを判定(見切りがあればpriorityを0にする、もしくは条件文に見切り判定を追加するなど)した方が
1. コードのどの場所でfollowupAttackPriorityを変化させても対応できる
2. インデントが一段下がる
ので後々楽かもしれません。