### PR TITLE
聖印の生命の護符の低い方参照無効が働かないバグの修正

### DIFF
--- a/Sources/DamageCalculator.js
+++ b/Sources/DamageCalculator.js
@@ -799,9 +799,14 @@ class DamageCalculator {
     }
 
     __canInvalidateReferenceLowerMit(defUnit) {
-        return defUnit.battleContext.invalidatesReferenceLowerMit ||
-            defUnit.passiveB === PassiveB.SeimeiNoGofu3 ||
-            defUnit.passiveB === PassiveB.HikariToYamito;
+        for (let skillId of defUnit.enumerateSkills()) {
+            switch(skillId) {
+                case PassiveB.SeimeiNoGofu3:
+                case PassiveB.HikariToYamito:
+                    return true;
+            }
+        }
+        return defUnit.battleContext.invalidatesReferenceLowerMit;
     }
 
     __calcCombatDamage(atkUnit, defUnit, context) {


### PR DESCRIPTION
低い方参照無効判定の際にenumerateSkillsを使用しないで直接defUnit.passiveBを参照していたためpassiveSに護符がある場合に正しく判定できていなかったので修正。