### PR TITLE
わがままな子兎で登場した超英雄の新スキルとミルラの双界スキルの実装

### DIFF
--- a/Sources/DamageCalculator.js
+++ b/Sources/DamageCalculator.js
@@ -1309,6 +1309,11 @@ class DamageCalculator {
         let damageReductionRatio = 1.0 - defUnit.battleContext.damageReductionRatioForPrecombat;
         for (let skillId of defUnit.enumerateSkills()) {
             switch (skillId) {
+                case Weapon.LilacJadeBreath:
+                    if (atkUnit.battleContext.initiatesCombat || atkUnit.snapshot.restHpPercentage === 100) {
+                        damageReductionRatio *= 1.0 - 0.4;
+                    }
+                    break;
                 case Weapon.Areadbhar:
                     let diff = defUnit.getEvalSpdInPrecombat() - atkUnit.getEvalSpdInPrecombat();
                     if (diff > 0 && defUnit.snapshot.restHpPercentage >= 25) {
@@ -1481,6 +1486,11 @@ class DamageCalculator {
 
     __getDamageReductionRatio(skillId, atkUnit, defUnit) {
         switch (skillId) {
+            case Weapon.LilacJadeBreath:
+                if (atkUnit.battleContext.initiatesCombat || atkUnit.snapshot.restHpPercentage === 100) {
+                    return 0.4;
+                }
+                break;
             case Weapon.Areadbhar:
                 let diff = defUnit.getEvalSpdInCombat(atkUnit) - atkUnit.getEvalSpdInCombat(defUnit);
                 if (diff > 0 && defUnit.snapshot.restHpPercentage >= 25) {

--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -5774,6 +5774,14 @@ class AetherRaidTacticsBoard {
 
         for (let skillId of targetUnit.enumerateSkills()) {
             switch (skillId) {
+                case Weapon.SpringyBowPlus:
+                    if (enemyUnit.snapshot.restHpPercentage >= 75) {
+                        targetUnit.atkSpur += 5;
+                        targetUnit.spdSpur += 5;
+                        targetUnit.battleContext.invalidatesOwnAtkDebuff = true;
+                        targetUnit.battleContext.invalidatesOwnSpdDebuff = true;
+                    }
+                    break;
                 case Weapon.LilacJadeBreath:
                     if (enemyUnit.battleContext.initiatesCombat || enemyUnit.snapshot.restHpPercentage === 100) {
                         targetUnit.addAllSpur(5);

--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -5775,6 +5775,7 @@ class AetherRaidTacticsBoard {
         for (let skillId of targetUnit.enumerateSkills()) {
             switch (skillId) {
                 case Weapon.SpringyBowPlus:
+                case Weapon.SpringyAxePlus:
                     if (enemyUnit.snapshot.restHpPercentage >= 75) {
                         targetUnit.atkSpur += 5;
                         targetUnit.spdSpur += 5;

--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -852,6 +852,12 @@ class AetherRaidTacticsBoard {
             return;
         }
         switch (duoUnit.heroIndex) {
+            case Hero.HarmonizedMyrrh: {
+                this.__addStatusEffectToSameOriginUnits(duoUnit, StatusEffectType.ResonantBlades);
+                this.__addStatusEffectToSameOriginUnits(duoUnit, StatusEffectType.FollowUpAttackMinus);
+                duoUnit.addStatusEffect(StatusEffectType.ShieldFlying);
+                break;
+            }
             case Hero.DuoLif: {
                 let damage = 0;
                 for (let unit of this.enumerateUnitsInTheSameGroupWithinSpecifiedSpaces(duoUnit, 3)) {
@@ -3930,6 +3936,10 @@ class AetherRaidTacticsBoard {
 
         if (!this.__canInvalidateInvalidationOfFollowupAttack(atkUnit, defUnit)) {
             followupAttackPriority += atkUnit.battleContext.followupAttackPriorityDecrement;
+
+            if (defUnit.hasStatusEffect(StatusEffectType.FollowUpAttackMinus)) {
+                --followupAttackPriority;
+            }
 
             if (defUnit.hasStatusEffect(StatusEffectType.ResonantShield) && defUnit.isOneTimeActionActivatedForShieldEffect == false) {
                 --followupAttackPriority;
@@ -8449,6 +8459,12 @@ class AetherRaidTacticsBoard {
     }
 
     isEffectiveAttackInvalidated(unit, effective) {
+        if (unit.hasStatusEffect(StatusEffectType.ShieldFlying)) {
+            if (effective === EffectiveType.Flying) {
+                return true;
+            }
+        }
+
         if (unit.hasStatusEffect(StatusEffectType.SieldDragonArmor)) {
             if (effective == EffectiveType.Armor
                 || effective == EffectiveType.Dragon

--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -5774,6 +5774,11 @@ class AetherRaidTacticsBoard {
 
         for (let skillId of targetUnit.enumerateSkills()) {
             switch (skillId) {
+                case Weapon.LilacJadeBreath:
+                    if (enemyUnit.battleContext.initiatesCombat || enemyUnit.snapshot.restHpPercentage === 100) {
+                        targetUnit.addAllSpur(5);
+                    }
+                    break;
                 case Weapon.TallHammer:
                     if (targetUnit.isWeaponRefined) {
                         // 周囲1マスにいない時の強化は別の処理で行っているため、ここでは除外

--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -5776,6 +5776,7 @@ class AetherRaidTacticsBoard {
             switch (skillId) {
                 case Weapon.SpringyBowPlus:
                 case Weapon.SpringyAxePlus:
+                case Weapon.SpringyLancePlus:
                     if (enemyUnit.snapshot.restHpPercentage >= 75) {
                         targetUnit.atkSpur += 5;
                         targetUnit.spdSpur += 5;

--- a/Sources/Skill.js
+++ b/Sources/Skill.js
@@ -968,6 +968,7 @@ const Weapon = {
     // わがままな子兎
     LilacJadeBreath: 1676, // 紫翠のブレス
     SpringyBowPlus: 1673, // 春兎の弓+
+    SpringyAxePlus: 1677, // 春兎の斧+
 
     Skinfaxi: 1679, // スキンファクシ
 };

--- a/Sources/Skill.js
+++ b/Sources/Skill.js
@@ -967,6 +967,7 @@ const Weapon = {
 
     // わがままな子兎
     LilacJadeBreath: 1676, // 紫翠のブレス
+    SpringyBowPlus: 1673, // 春兎の弓+
 
     Skinfaxi: 1679, // スキンファクシ
 };

--- a/Sources/Skill.js
+++ b/Sources/Skill.js
@@ -965,6 +965,9 @@ const Weapon = {
     IcyFimbulvetr: 1668, // 氷槍フィンブル
     BansheeTheta: 1670, // バンシーθ
 
+    // わがままな子兎
+    LilacJadeBreath: 1676, // 紫翠のブレス
+
     Skinfaxi: 1679, // スキンファクシ
 };
 

--- a/Sources/Skill.js
+++ b/Sources/Skill.js
@@ -969,6 +969,7 @@ const Weapon = {
     LilacJadeBreath: 1676, // 紫翠のブレス
     SpringyBowPlus: 1673, // 春兎の弓+
     SpringyAxePlus: 1677, // 春兎の斧+
+    SpringyLancePlus: 1674, // 春兎の槍+
 
     Skinfaxi: 1679, // スキンファクシ
 };

--- a/Sources/Unit.js
+++ b/Sources/Unit.js
@@ -47,6 +47,7 @@ const Hero = {
     DuoPeony: 615,
     PlegianDorothea: 625,
     DuoLif: 631,
+    HarmonizedMyrrh: 648
 };
 
 function isThiefIndex(heroIndex) {
@@ -213,6 +214,8 @@ const StatusEffectType = {
     Vantage: 15, // 待ち伏せ
     DeepWounds: 16, // 回復不可
     FallenStar: 17, // 落星
+    ShieldFlying: 18, // 飛行特効無効
+    FollowUpAttackMinus: 19, // 追撃不可
 };
 
 /// シーズンが光、闇、天、理のいずれかであるかを判定します。
@@ -307,6 +310,12 @@ function statusEffectTypeToIconFilePath(value) {
             return g_imageRootPath + "StatusEffect_DeepWounds.png";
         case StatusEffectType.FallenStar:
             return g_imageRootPath + "StatusEffect_FallenStar.png";
+        case StatusEffectType.FollowUpAttackMinus:
+            // @TODO: 画像追加
+            return g_imageRootPath + "StatusEffect_ResonantShield.png";
+        case StatusEffectType.ShieldFlying:
+            // @TODO: 画像追加
+            return g_imageRootPath + "StatusEffect_SieldDragonArmor.png";
         default: return "";
     }
 }
@@ -2305,6 +2314,7 @@ class Unit {
                 || this.heroIndex == Hero.DuoPeony
                 || this.heroIndex == Hero.PlegianDorothea
                 || this.heroIndex == Hero.DuoLif
+                || this.heroIndex == Hero.HarmonizedMyrrh
             );
     }
 


### PR DESCRIPTION
ミルラの双界スキルの
- 飛行特効無効
- 追撃不可
についてはアイコンが存在しなかったのでそれぞれ重装・竜特効無効、双界盾のアイコンを流用。

セレナの武器に関しては「すでに戦闘を行った」判定に時間がかかりそうなのでとりあえず保留で他のスキルの実装を優先。