### PR TITLE
ひとりぼっちのゆめと重装の行軍、飛行獣の化身で「移動+1」ステータスを付与するように修正

### DIFF
--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -11271,8 +11271,10 @@ class AetherRaidTacticsBoard {
         if (isWeaponTypeBeast(skillOwner.weaponType) && skillOwner.hasWeapon) {
             if (!this.__isNextToOtherUnitsExceptDragonAndBeast(skillOwner)) {
                 skillOwner.isTransformed = true;
-            }
-            else {
+                if (skillOwner.moveType === MoveType.Flying && isWeaponTypeBeast(skillOwner.weaponType)) {
+                    skillOwner.reserveToAddStatusEffect(StatusEffectType.MobilityIncreased);
+                }
+            } else {
                 skillOwner.isTransformed = false;
             }
         }

--- a/Sources/Main.js
+++ b/Sources/Main.js
@@ -11986,7 +11986,7 @@ class AetherRaidTacticsBoard {
             case PassiveC.SolitaryDream:
                 if (!this.__isNextToOtherUnitsExcept(skillOwner, x => isWeaponTypeBreath(x.weaponType))) {
                     skillOwner.applyAllBuff(4);
-                    skillOwner.moveCount = 2;
+                    skillOwner.reserveToAddStatusEffect(StatusEffectType.MobilityIncreased);
                 }
                 break;
             case PassiveC.WithEveryone:
@@ -12570,9 +12570,9 @@ class AetherRaidTacticsBoard {
                 for (let unit of this.enumerateUnitsInTheSameGroupWithinSpecifiedSpaces(skillOwner, 1, false)) {
                     if (unit.moveType == MoveType.Armor) {
                         this.writeLogLine(unit.getNameWithGroup() + "は重装の行軍により移動値+1");
-                        unit.moveCount = 2;
+                        unit.reserveToAddStatusEffect(StatusEffectType.MobilityIncreased);
                         this.writeLogLine(skillOwner.getNameWithGroup() + "は重装の行軍により移動値+1");
-                        skillOwner.moveCount = 2;
+                        skillOwner.reserveToAddStatusEffect(StatusEffectType.MobilityIncreased);
                     }
                 }
                 break;

--- a/Sources/Unit.js
+++ b/Sources/Unit.js
@@ -3232,13 +3232,6 @@ class Unit {
             }
             return this.getNormalMoveCount() + 1;
         }
-        if (this.isTransformed
-            && this.moveType == MoveType.Flying
-            && isWeaponTypeBeast(this.weaponType)
-        ) {
-            return 3;
-        }
-
         return this._moveCount;
     }
 


### PR DESCRIPTION
ひとりぼっちのゆめと重装の行軍で直接moveCount = 2とするのではなく「移動+1」ステータスを付与するように修正しました。
（ゆめ、行軍の「移動+1」効果を万全スキルで有利な状態として扱うようにするため。また空転の判定も正しく行われるようにするため）