### PR TITLE
範囲奥義関連のバグを修正

### DIFF
--- a/Sources/DamageCalculator.js
+++ b/Sources/DamageCalculator.js
@@ -640,6 +640,10 @@ class DamageCalculator {
         return totalDamage;
     }
 
+    /**
+     * @param  {Unit} atkUnit
+     * @param  {Unit} defUnit
+    */
     calcPrecombatSpecialDamage(atkUnit, defUnit) {
         let tmpMit = atkUnit.battleContext.refersRes ? defUnit.getResInPrecombat() : defUnit.getDefInPrecombat();
         if (defUnit.battleContext.isOnDefensiveTile) {

--- a/Sources/DamageCalculatorWrapper.js
+++ b/Sources/DamageCalculatorWrapper.js
@@ -292,6 +292,15 @@ class DamageCalculatorWrapper {
     }
 
     calcPrecombatSpecialDamage(atkUnit, defUnit) {
+        // 範囲奥義と戦闘中のどちらにも効くスキル効果の適用
+        this.__applySkillEffectForPrecombatAndCombat(atkUnit, defUnit, false);
+        this.__applySkillEffectForPrecombatAndCombat(defUnit, atkUnit, false);
+
+        // 戦闘前ダメージ計算に影響するスキル効果の評価
+        this.__applyPrecombatSpecialDamageMult(atkUnit);
+        this.__applyPrecombatDamageReductionRatio(defUnit, atkUnit);
+        this.__calcFixedAddDamage(atkUnit, defUnit, true);
+        DamageCalculatorWrapper.__calcFixedSpecialAddDamage(atkUnit, defUnit, true);
         return this._damageCalc.calcPrecombatSpecialDamage(atkUnit, defUnit);
     }
 

--- a/Sources/DamageCalculatorWrapper.js
+++ b/Sources/DamageCalculatorWrapper.js
@@ -292,19 +292,15 @@ class DamageCalculatorWrapper {
     }
 
     calcPrecombatSpecialDamage(atkUnit, defUnit) {
-        // 範囲奥義と戦闘中のどちらにも効くスキル効果の適用
-        this.__applySkillEffectForPrecombatAndCombat(atkUnit, defUnit, false);
-        this.__applySkillEffectForPrecombatAndCombat(defUnit, atkUnit, false);
-
-        // 戦闘前ダメージ計算に影響するスキル効果の評価
-        this.__applyPrecombatSpecialDamageMult(atkUnit);
-        this.__applyPrecombatDamageReductionRatio(defUnit, atkUnit);
-        this.__calcFixedAddDamage(atkUnit, defUnit, true);
-        DamageCalculatorWrapper.__calcFixedSpecialAddDamage(atkUnit, defUnit, true);
+        this.__applyPrecombatSkills(atkUnit, defUnit);
         return this._damageCalc.calcPrecombatSpecialDamage(atkUnit, defUnit);
     }
 
-    calcPrecombatSpecialResult(atkUnit, defUnit) {
+    /**
+     * @param  {Unit} saverUnit
+     * @param  {Unit} defUnit
+     */
+    __applyPrecombatSkills(atkUnit, defUnit) {
         // 範囲奥義と戦闘中のどちらにも効くスキル効果の適用
         this.__applySkillEffectForPrecombatAndCombat(atkUnit, defUnit, false);
         this.__applySkillEffectForPrecombatAndCombat(defUnit, atkUnit, false);
@@ -318,10 +314,21 @@ class DamageCalculatorWrapper {
         // 守備、魔防のどちらを参照するか決定
         defUnit.battleContext.invalidatesReferenceLowerMit = this.__canInvalidatesReferenceLowerMit(defUnit, atkUnit);
         this.__selectReferencingResOrDef(atkUnit, defUnit);
-
-        return this._damageCalc.calcPrecombatSpecialResult(atkUnit, defUnit);
     }
 
+    /**
+     * @param  {Unit} saverUnit
+     * @param  {Unit} defUnit
+     */
+    calcPrecombatSpecialResult(atkUnit, defUnit) {
+        this.__applyPrecombatSkills(atkUnit, defUnit);
+        return this._damageCalc.calcPrecombatSpecialResult(atkUnit, defUnit);
+    }
+    /**
+     * @param  {Unit} saverUnit
+     * @param  {Unit} defUnit
+     * @param  {DamageType} damageType
+     */
     calcCombatResult(atkUnit, defUnit, damageType) {
         let calcPotentialDamage = damageType === DamageType.PotentialDamage;
         let self = this;

--- a/Sources/Skill.js
+++ b/Sources/Skill.js
@@ -2808,10 +2808,7 @@ EvalSpdAddDict[PassiveS.HayasaNoKyosei3] = 10;
 /// 速さ比較時の速さ加算値を取得します。
 function getEvalSpdAdd(passiveS) {
     let value = EvalSpdAddDict[passiveS];
-    if (value) {
-        return value;
-    }
-    return 0;
+    return value ? value : 0;
 }
 
 const EvalResAddDict = {};
@@ -2821,7 +2818,8 @@ EvalResAddDict[PassiveS.MaboNoKyosei3] = 10;
 
 /// 魔防比較時の速さ加算値を取得します。
 function getEvalResAdd(passiveS) {
-    return passiveS in EvalResAddDict;
+    let value = EvalResAddDict[passiveS];
+    return value ? value : 0;
 }
 
 const WeaponTypesAddAtk2AfterTransform = {};

--- a/Sources/Unit.js
+++ b/Sources/Unit.js
@@ -606,14 +606,14 @@ class BattleContext {
 
     /// 戦闘のダメージ計算時の残りHPです。
     get restHpPercentage() {
-        if (this.restHp === this.maxHpWithSkills) {
+        if (this.restHp == this.maxHpWithSkills) {
             return 100;
         }
         return 100 * this.restHp / this.maxHpWithSkills;
     }
 
     get isRestHpFull() {
-        return this.restHp === this.maxHpWithSkills;
+        return this.restHp == this.maxHpWithSkills;
     }
 
     invalidateAllBuffs() {
@@ -4446,7 +4446,7 @@ class Unit {
     }
 
     canActivatePrecombatSpecial() {
-        return isPrecombatSpecial(this.special) && this.specialCount === 0;
+        return isPrecombatSpecial(this.special) && Number(this.specialCount) === 0;
     }
 
     /**

--- a/Sources/Unit.js
+++ b/Sources/Unit.js
@@ -574,6 +574,8 @@ class BattleContext {
         this.followupAttackPriorityIncrement = 0;
         this.followupAttackPriorityDecrement = 0;
 
+        this.damageReductionRatioForPrecombat = 0;
+
         this.isSaviorActivated = false;
 
         this.additionalDamageOfFirstAttack = 0;


### PR DESCRIPTION
1. BattleContextの範囲奥義のダメージ軽減の値がリセットされていないバグの修正
2. 魔防の虚勢のバグの修正
3. 範囲奥義に他のキャラ経由で巻き込まれた場合に戦闘前に有効なスキルを評価していないバグの修正