### PR TITLE
ベレスの奥義スキルのダメージ軽減が奥義での軽減になるように修正

### DIFF
--- a/Sources/DamageCalculator.js
+++ b/Sources/DamageCalculator.js
@@ -783,12 +783,6 @@ class DamageCalculator {
 
             // 奥義以外のダメージ軽減
             {
-                // 次の攻撃のダメージ軽減
-                for (let ratio of defUnit.battleContext.damageReductionRatiosOfNextAttack) {
-                    defUnit.battleContext.multDamageReductionRatio(ratio, atkUnit);
-                }
-                defUnit.battleContext.damageReductionRatiosOfNextAttack = [];
-
                 // 計算機の外側で設定されたダメージ軽減率
                 damageReductionRatio *= 1.0 - defUnit.battleContext.damageReductionRatio;
 
@@ -815,6 +809,12 @@ class DamageCalculator {
 
             // 奥義によるダメージ軽減
             let isDefenderSpecialActivated = false;
+            // 奥義の次の攻撃のダメージ軽減
+            for (let ratio of defUnit.battleContext.damageReductionRatiosBySpecialOfNextAttack) {
+                damageReductionRatio *= 1.0 - ratio;
+            }
+            defUnit.battleContext.damageReductionRatiosBySpecialOfNextAttack = [];
+
             if (activatesDefenderSpecial) {
                 if (defUnit.battleContext.damageReductionRatioBySpecial > 0) {
                     damageReductionRatio *= 1.0 - defUnit.battleContext.damageReductionRatioBySpecial;
@@ -841,7 +841,7 @@ class DamageCalculator {
                 atkUnit.battleContext.isSpecialActivated = true;
                 switch (atkUnit.special) {
                     case Special.DevinePulse: {
-                        atkUnit.battleContext.damageReductionRatiosOfNextAttack.push(0.75);
+                        atkUnit.battleContext.damageReductionRatiosBySpecialOfNextAttack.push(0.75);
                         let spd = atkUnit.getSpdInCombat(defUnit);
                         atkUnit.battleContext.additionalDamageOfNextAttack += Math.trunc(spd * 0.2);
                     }

--- a/Sources/Unit.js
+++ b/Sources/Unit.js
@@ -484,7 +484,7 @@ class BattleContext {
         this.damageReductionRatioBySpecial = 0;
 
         // 次の敵の攻撃ダメージ軽減
-        this.damageReductionRatiosOfNextAttack = [];
+        this.damageReductionRatiosBySpecialOfNextAttack = [];
 
         // 護り手が発動しているかどうか
         this.isSaviorActivated = false;
@@ -645,7 +645,7 @@ class BattleContext {
         this.refersResForSpecial = false;
         this.reducedDamageForNextAttack = 0;
         this.additionalDamageOfNextAttack = 0;
-        this.damageReductionRatiosOfNextAttack = [];
+        this.damageReductionRatiosBySpecialOfNextAttack = [];
         this.nextAttackEffectAfterSpecialActivated = false;
 
         // 自身の発動カウント変動量-1を無効
@@ -741,7 +741,7 @@ class BattleContext {
         return 1 - (1 - sourceRatio) * (1 - modifiedRatio);
     }
 
-    // 範囲奥義のダメージ軽減積
+    // 奥義のダメージ軽減積
     static multDamageReductionRatioForSpecial(sourceRatio, ratio) {
         return 1 - (1 - sourceRatio) * (1 - ratio);
     }


### PR DESCRIPTION
ベレスの奥義スキルにある次の攻撃のダメージ軽減を奥義以外の軽減として扱っていたので奥義での軽減になるように修正