### PR TITLE
移動補助スキル発動後に罠の処理を行うように修正

### DIFF
--- a/Sources/BattleSimulatorBase.js
+++ b/Sources/BattleSimulatorBase.js
@@ -7592,14 +7592,21 @@ class BattleSimmulatorBase {
             g_appData.map.removeUnit(targetUnit);
         }
 
-        moveUnit(unit, result.assistUnitTileAfterAssist, false, executesTrap);
+        // 罠は移動補助スキルの後に効果を発動するのでexecutesTrapをtrueで呼び出す
+        moveUnit(unit, result.assistUnitTileAfterAssist, false, false);
         if (movesTargetUnit) {
-            moveUnit(targetUnit, result.targetUnitTileAfterAssist, false, executesTrap);
+            moveUnit(targetUnit, result.targetUnitTileAfterAssist, false, false);
         }
 
         if (applysMovementSkill) {
             this.__applyMovementAssistSkill(unit, targetUnit);
             this.__applyMovementAssistSkill(targetUnit, unit);
+        }
+
+        // 移動補助スキルの処理が終了したので罠を発動させる
+        if (executesTrap) {
+            executeTrapIfPossible(unit, false);
+            executeTrapIfPossible(targetUnit, false);
         }
         return true;
     }


### PR DESCRIPTION
例えばユーミルのぶちかましで重圧トラップ発動の条件を満たすターゲットを重圧の罠に飛ばした場合に
ユーミルの補助での異常状態解除 => 重圧処理
でグラビティ状態が残るのが正しい挙動ですが実装では
重圧処理 => ユーミルの補助での異常状態解除
となりグラビティ状態を解除してしまっていたので評価順序を入れ替えました。