### PR TITLE
破壊可能な壁のbreakCountをマップのリセット時に初期化するように修正

### DIFF
--- a/Sources/BattleMapSettings.js
+++ b/Sources/BattleMapSettings.js
@@ -1338,6 +1338,9 @@ function __resetBattleMapPlacementForArena(map, type, withUnits) {
  * @param  {MapType} type
  */
 function __resetBattleMapPlacementForAetherRaid(map, type) {
+    for (let breakableWall of map._breakableWalls) {
+        breakableWall.reset();
+    }
     switch (type) {
         case MapType.None:
             break;

--- a/Sources/Structures.js
+++ b/Sources/Structures.js
@@ -937,6 +937,10 @@ class BreakableWall extends DefenceStructureBase {
 
         --this.breakCount;
     }
+
+    reset(breakCount = 1) {
+        this.breakCount = breakCount;
+    }
 }
 
 /// ユニットが通行可能な配置物であるかどうかを判定します。


### PR DESCRIPTION
巨人マップで壁のbreakCountが2にセットされてしまうと異なるマップを再選択した時にカウントが2のままになっていたのでマップ選択時にリセットするように修正。