### PR TITLE
バグの修正(神速追撃のダメージ計算、戦闘後HP回復など)

### DIFF
--- a/Sources/BattleContext.js
+++ b/Sources/BattleContext.js
@@ -668,4 +668,11 @@ class BattleContext {
     canAttackInCombat() {
         return this.initiatesCombat || this.canCounterattack;
     }
+
+    // TODO: リファクタリングする
+    resetHealOrDamageAfterCombat() {
+        this.healedHpAfterCombat = 0;
+        this.healedHpAfterAttackSpecialInCombat = 0;
+        this.damageAfterCombat = 0;
+    }
 }

--- a/Sources/DamageCalculator.js
+++ b/Sources/DamageCalculator.js
@@ -1288,20 +1288,21 @@ class DamageCalculator {
             }
 
             // 神速追撃によるダメージ軽減
+            let potentRatio = 1;
             if (context.isPotentFollowupAttack) {
                 if (atkUnit.battleContext.potentOverwriteRatio === null) {
                     for (let ratio of atkUnit.battleContext.potentRatios) {
-                        let oldRatio = damageReductionRatio;
-                        damageReductionRatio *= ratio;
-                        this.writeDebugLog(`神速追撃による軽減。ratio: ${ratio}, damage ratio: ${oldRatio} → ${damageReductionRatio}`);
+                        let oldRatio = potentRatio;
+                        potentRatio *= ratio;
+                        this.writeDebugLog(`神速追撃による軽減。ratio: ${ratio}, damage ratio: ${oldRatio} → ${potentRatio}`);
                         this.writeSimpleLog(`神速追撃:ダメージ${ratio * 100}%`)
                     }
                 } else {
                     let ratio = atkUnit.battleContext.potentOverwriteRatio;
                     this.writeDebugLog(`神速追撃上書き値による軽減。ratios: ${atkUnit.battleContext.potentRatios} → ratio: ${ratio}`);
-                    let oldRatio = damageReductionRatio;
-                    damageReductionRatio *= ratio;
-                    this.writeDebugLog(`神速追撃による軽減。ratio: ${ratio}, damage ratio: ${oldRatio} → ${damageReductionRatio}`);
+                    let oldRatio = potentRatio;
+                    potentRatio *= ratio;
+                    this.writeDebugLog(`神速追撃による軽減。ratio: ${ratio}, damage ratio: ${oldRatio} → ${potentRatio}`);
                     this.writeSimpleLog(`神速追撃:ダメージ${ratio * 100}%`)
                 }
             }
@@ -1342,8 +1343,14 @@ class DamageCalculator {
                 // 奥義発動
                 damageReductionValue += defUnit.battleContext.damageReductionValueOfSpecialAttack;
                 damageReductionValue += defUnit.battleContext.damageReductionValueOfSpecialAttackPerAttack;
-                currentDamage = this.__calcUnitAttackDamage(defUnit, atkUnit, specialDamage, damageReductionRatio, damageReductionValue, activatesDefenderSpecial, context);
-                if (this.isLogEnabled) this.writeLog(`奥義によるダメージ${currentDamage}`);
+                currentDamage = this.__calcUnitAttackDamage(
+                    defUnit, atkUnit,
+                    specialDamage,
+                    damageReductionRatio, damageReductionValue,
+                    potentRatio,
+                    activatesDefenderSpecial, context
+                );
+                if (this.isLogEnabled) this.writeLog(`<span style="color: #ff00ff">奥義</span>によるダメージ<span style="color: #ff0000;">${currentDamage}</span>`);
                 let atkColor = atkUnit.groupId === UnitGroupType.Ally ? "blue" : "red";
                 let defColor = defUnit.groupId === UnitGroupType.Ally ? "blue" : "red";
                 this.writeSimpleLog(`<span style="color: ${atkColor};">${atkUnit.getNameWithGroup()}</span>→<span style="color: ${defColor};">${defUnit.getNameWithGroup()}</span><br/><span style="color: #ff00ff">奥義</span>ダメージ<span style="color: #ff0000;">${currentDamage}</span>`);
@@ -1373,8 +1380,14 @@ class DamageCalculator {
                 }
             } else {
                 // 通常攻撃
-                currentDamage = this.__calcUnitAttackDamage(defUnit, atkUnit, normalDamage, damageReductionRatio, damageReductionValue, activatesDefenderSpecial, context);
-                if (this.isLogEnabled) this.writeLog(`通常攻撃によるダメージ${currentDamage}`);
+                currentDamage = this.__calcUnitAttackDamage(
+                    defUnit, atkUnit,
+                    normalDamage,
+                    damageReductionRatio, damageReductionValue,
+                    potentRatio,
+                    activatesDefenderSpecial, context
+                );
+                if (this.isLogEnabled) this.writeLog(`通常攻撃によるダメージ<span style="color: #ff0000;">${currentDamage}</span>`);
                 let atkColor = atkUnit.groupId === UnitGroupType.Ally ? "blue" : "red";
                 let defColor = defUnit.groupId === UnitGroupType.Ally ? "blue" : "red";
                 this.writeSimpleLog(`<span style="color: ${atkColor};">${atkUnit.getNameWithGroup()}</span>→<span style="color: ${defColor};">${defUnit.getNameWithGroup()}</span><br/>通常攻撃ダメージ<span style="color: #ff0000;">${currentDamage}</span>`);
@@ -1785,19 +1798,25 @@ class DamageCalculator {
      * @param {number} damage
      * @param {number} damageReductionRatio
      * @param {number|string} damageReductionValue
+     * @param {number} potentRatio
      * @param {boolean} activatesDefenderSpecial
      * @param {DamageCalcContext} context
      */
-    __calcUnitAttackDamage(defUnit, atkUnit, damage, damageReductionRatio, damageReductionValue, activatesDefenderSpecial, context) {
-        let reducedDamage = floorNumberWithFloatError(damage * damageReductionRatio) + damageReductionValue;
+    __calcUnitAttackDamage(defUnit, atkUnit,
+                           damage,
+                           damageReductionRatio, damageReductionValue,
+                           potentRatio,
+                           activatesDefenderSpecial, context) {
+        let reducedDamage = Math.trunc(damage * damageReductionRatio) + damageReductionValue;
         let currentDamage = Math.max(damage - reducedDamage, 0);
-        if (damageReductionRatio > 0.0) {
-            if (this.isLogEnabled) this.writeDebugLog("ダメージ軽減率" + floorNumberWithFloatError(damageReductionRatio * 100) + "%");
-            if (this.isLogEnabled) this.writeDebugLog("固定ダメージ軽減値-" + damageReductionValue);
-            if (this.isLogEnabled) this.writeDebugLog("ダメージ変化:" + damage + "→" + currentDamage);
-        } else if (damageReductionValue > 0) {
-            if (this.isLogEnabled) this.writeDebugLog("固定ダメージ軽減値-" + damageReductionValue);
-            if (this.isLogEnabled) this.writeDebugLog("ダメージ変化:" + damage + "→" + currentDamage);
+        currentDamage = Math.trunc(currentDamage * potentRatio);
+        if (this.isLogEnabled) {
+            this.writeDebugLog(`ダメージ計算: (${damage} - trunc(${damage} * ${roundFloat(damageReductionRatio)})) - ${damageReductionValue}) * ${potentRatio} = ${currentDamage}`);
+            this.writeDebugLog(`軽減前ダメージ${damage}`);
+            this.writeDebugLog(`ダメージ軽減率${floorNumberWithFloatError(damageReductionRatio * 100)}%`);
+            this.writeDebugLog(`固定ダメージ軽減値-${damageReductionValue}`);
+            this.writeDebugLog(`神速追撃ダメージ倍率${floorNumberWithFloatError(potentRatio * 100)}%`);
+            this.writeDebugLog(`ダメージ変化:${damage}→${currentDamage} (${damage - currentDamage}軽減)`);
         }
 
         if (activatesDefenderSpecial && !defUnit.battleContext.preventedDefenderSpecial) {

--- a/Sources/DamageCalculator.js
+++ b/Sources/DamageCalculator.js
@@ -136,7 +136,9 @@ class DamageCalcResult {
     }
 }
 
-/// ダメージ計算を行うためのクラスです。
+/**
+ * ダメージ計算を行うためのクラスです。
+ */
 class DamageCalculator {
     /**
      * @param  {LoggerBase} logger

--- a/Sources/Logger.js
+++ b/Sources/Logger.js
@@ -85,19 +85,19 @@ class HtmlLogger extends LoggerBase {
             return;
         }
 
-        this._simpleLog += log + "<br/>";
+        this._simpleLog += `${log}<br/>`;
     }
 
     writeLog(log) {
         if (!this.isLogEnabled) {
             return;
         }
-        this._log += log + "<br/>";
+        this._log += "<span style='font-size:10px; color:#000000'>" + log + "</span><br/>";
     }
     writeDebugLog(log) {
         if (!this.isLogEnabled) {
             return;
         }
-        this._log += "<span style='font-size:10px; color:#666666'>" + log + "</span><br/>";
+        this._log += `<span style='font-size:10px; color:#666666'>${log}</span><br/>`;
     }
 }

--- a/Sources/PostCombatSkillHander.js
+++ b/Sources/PostCombatSkillHander.js
@@ -136,7 +136,10 @@ class PostCombatSkillHander {
         for (let unit of this.enumerateAllUnitsOnMap()) {
             unit.modifySpecialCount();
             if (!unit.isDead) {
-                unit.applyReservedHp(true);
+                let [hp, damage, heal] = unit.applyReservedHp(true);
+                if (damage !== 0 || heal !== 0) {
+                    this.writeDebugLogLine(`${unit.nameWithGroup}の戦闘後HP hp: ${hp}, damage: ${damage}, heal: ${heal}`);
+                }
             }
         }
 
@@ -789,6 +792,8 @@ class PostCombatSkillHander {
         if (targetUnit.isAlive) {
             targetUnit.reserveHeal(targetUnit.battleContext.healedHpAfterCombat);
             targetUnit.reserveTakeDamage(targetUnit.battleContext.damageAfterCombat);
+            // TODO: リファクタリングする
+            targetUnit.battleContext.resetHealOrDamageAfterCombat();
             if (targetUnit.battleContext.isChainGuardActivated) {
                 targetUnit.reserveTakeDamage(1);
             }

--- a/Sources/SkillImpl.js
+++ b/Sources/SkillImpl.js
@@ -1084,15 +1084,16 @@
             if (targetUnit.battleContext.isSpecialActivated) {
                 // 自身を中心とした縦3列と横3列にいる敵に
                 /** @type {Generator<Unit>} */
-                let units = this.enumerateUnitsInDifferentGroupOnMap(targetUnit);
+                let enemies = this.enumerateUnitsInDifferentGroupOnMap(targetUnit);
                 let count = 0;
-                for (let unit of units) {
-                    if (unit.isInCrossWithOffset(targetUnit, 1)) {
+                for (let enemy of enemies) {
+                    if (enemy.isInCrossWithOffset(targetUnit, 1)) {
+                        this.writeDebugLogLine(`${enemy.nameWithGroup}`);
                         count++;
                         // 5ダメージ、
-                        unit.reserveTakeDamage(5);
+                        enemy.reserveTakeDamage(5);
                         // 奥義発動カウント＋1（奥義発動カウントの最大値は超えない）、
-                        unit.increaseSpecialCount(1);
+                        enemy.increaseSpecialCount(1);
                     }
                 }
                 // 自分は、HPが回復
@@ -2763,10 +2764,9 @@
     applySkillForBeginningOfTurnFuncMap.set(skillId,
         function (skillOwner) {
             let found = false;
-            /** @type {[Unit]} */
-            let units = this.enumerateUnitsInTheSameGroupOnMap(skillOwner);
-            for (let unit of units) {
-                if (unit.isPartner(skillOwner)) {
+            let allies = this.enumerateUnitsInTheSameGroupOnMap(skillOwner);
+            for (let ally of allies) {
+                if (ally.isPartner(skillOwner)) {
                     found = true;
                     break;
                 }

--- a/Sources/SkillImpl.js
+++ b/Sources/SkillImpl.js
@@ -593,6 +593,7 @@
             // ターン開始時、化身状態になる条件を満たしていれば、自分に「自分が移動可能な地形を平地のように移動可能」、「移動+1」(重複しない)を付与(1ターン)
             if (skillOwner.isTransformed) {
                 skillOwner.reserveToAddStatusEffect(StatusEffectType.UnitCannotBeSlowedByTerrain);
+                skillOwner.reserveToAddStatusEffect(StatusEffectType.MobilityIncreased);
             }
         }
     );

--- a/Sources/Unit.js
+++ b/Sources/Unit.js
@@ -2691,6 +2691,7 @@ class Unit extends BattleMapElement {
 
     /**
      * @param  {Boolean} leavesOneHp
+     * @returns {[number, number, number]} hp, damage, heal
      */
     applyReservedHp(leavesOneHp) {
         let healHp = this.hasStatusEffect(StatusEffectType.DeepWounds) ? 0 : this.reservedHeal;

--- a/Sources/Unit.js
+++ b/Sources/Unit.js
@@ -2700,6 +2700,7 @@ class Unit extends BattleMapElement {
 
         this.reservedDamage = 0;
         this.reservedHeal = 0;
+        return [this.hp, damageHp, healHp];
     }
 
     reserveTakeDamage(damageAmount) {

--- a/Sources/UnitManager.js
+++ b/Sources/UnitManager.js
@@ -84,7 +84,7 @@ class UnitManager {
      */
     * enumerateUnitsInDifferentGroupOnMap(targetUnit) {
         for (let unit of this.enumerateUnitsInDifferentGroup(targetUnit)) {
-            if (unit.isOnMap) {
+            if (unit.isOnMap && !unit.isDead) {
                 yield unit;
             }
         }


### PR DESCRIPTION
神速追撃のダメージカットについて
ダメージカット、神速追撃のダメージカット => ダメージマイナス(アスク算数など)
ではなく
ダメージカット => ダメージマイナス => 神速追撃のダメージカット
に修正

戦闘後HP回復について戦闘参加者以外の`battleContext`に設定した回復値が残り続けてしまうので回復予約後リセットするように修正。